### PR TITLE
disable support a learner in prod

### DIFF
--- a/src/components/Navbar/NavbarNavs.jsx
+++ b/src/components/Navbar/NavbarNavs.jsx
@@ -7,18 +7,28 @@ import useHandleCTAClick from '../../hooks/useHandleCTAClick';
 // import LoginModal from '../LoginModal';
 
 const { NAVBAR_LINKS_ID } = TestId;
+
 const NavbarNavs = ({ showMenu, closeMenu }) => {
   const { buttonLabel, handleCTAClick } = useHandleCTAClick();
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  const checkLocation = (path) => {
+    const isSupportALearner = path === NAVBAR_LINKS[0].to;
+    return isSupportALearner;
+  };
 
   return (
     <>
       <nav className="navbarNavs" data-testid={NAVBAR_LINKS_ID}>
         <div className="navContent">
-          {NAVBAR_LINKS.map((link) => (
-            <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }}>
-              {link.label}
-            </HashLink>
-          ))}
+          {NAVBAR_LINKS.map((link) => {
+            const supportALearnerInDev = checkLocation(link.to);
+            return (
+              <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }}>
+                {supportALearnerInDev && isDevelopment ? link.label : !supportALearnerInDev ? link.label : null}
+              </HashLink>
+            );
+          })}
         </div>
         <div className="navAction">
           <Button label={buttonLabel} type={BUTTON_TYPE} onClick={() => handleCTAClick()} className="navBtn" />
@@ -53,9 +63,9 @@ const NavbarNavs = ({ showMenu, closeMenu }) => {
   );
 };
 
-export default NavbarNavs;
-
 NavbarNavs.propTypes = {
   showMenu: PropTypes.bool,
   closeMenu: PropTypes.func
 };
+
+export default NavbarNavs;

--- a/src/components/Navbar/NavbarNavs.jsx
+++ b/src/components/Navbar/NavbarNavs.jsx
@@ -38,11 +38,14 @@ const NavbarNavs = ({ showMenu, closeMenu }) => {
       {showMenu ? (
         <nav className="mobile-nav">
           <div className="mobile-links">
-            {NAVBAR_LINKS.map((link) => (
-              <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }} onClick={() => closeMenu(!showMenu)}>
-                {link.label}
-              </HashLink>
-            ))}
+            {NAVBAR_LINKS.map((link) => {
+              const supportALearnerInDev = checkLocation(link.to);
+              return (
+                <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }} onClick={() => closeMenu(!showMenu)}>
+                  {supportALearnerInDev && isDevelopment ? link.label : !supportALearnerInDev ? link.label : null}
+                </HashLink>
+              );
+            })}
           </div>
           <div className="mobile-nav-btn">
             <Button


### PR DESCRIPTION
The support a learner link is accessible on the production site.
A fix pr for that, to only render it in development mode.
