### PR TITLE
feat: updated the reports page, and exposed the support a learner link

### DIFF
--- a/src/components/Navbar/NavbarNavs.jsx
+++ b/src/components/Navbar/NavbarNavs.jsx
@@ -10,25 +10,16 @@ const { NAVBAR_LINKS_ID } = TestId;
 
 const NavbarNavs = ({ showMenu, closeMenu }) => {
   const { buttonLabel, handleCTAClick } = useHandleCTAClick();
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  const checkLocation = (path) => {
-    const isSupportALearner = path === NAVBAR_LINKS[0].to;
-    return isSupportALearner;
-  };
 
   return (
     <>
       <nav className="navbarNavs" data-testid={NAVBAR_LINKS_ID}>
         <div className="navContent">
-          {NAVBAR_LINKS.map((link) => {
-            const supportALearnerInDev = checkLocation(link.to);
-            return (
-              <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }}>
-                {supportALearnerInDev && isDevelopment ? link.label : !supportALearnerInDev ? link.label : null}
-              </HashLink>
-            );
-          })}
+          {NAVBAR_LINKS.map((link) => (
+            <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }}>
+              {link.label}
+            </HashLink>
+          ))}
         </div>
         <div className="navAction">
           <Button label={buttonLabel} type={BUTTON_TYPE} onClick={() => handleCTAClick()} className="navBtn" />
@@ -38,14 +29,11 @@ const NavbarNavs = ({ showMenu, closeMenu }) => {
       {showMenu ? (
         <nav className="mobile-nav">
           <div className="mobile-links">
-            {NAVBAR_LINKS.map((link) => {
-              const supportALearnerInDev = checkLocation(link.to);
-              return (
-                <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }} onClick={() => closeMenu(!showMenu)}>
-                  {supportALearnerInDev && isDevelopment ? link.label : !supportALearnerInDev ? link.label : null}
-                </HashLink>
-              );
-            })}
+            {NAVBAR_LINKS.map((link) => (
+              <HashLink key={link.label} to={{ pathname: link.to, hash: link.hash }} onClick={() => closeMenu(!showMenu)}>
+                {link.label}
+              </HashLink>
+            ))}
           </div>
           <div className="mobile-nav-btn">
             <Button

--- a/src/sections/Reports/constants.js
+++ b/src/sections/Reports/constants.js
@@ -103,7 +103,12 @@ export const reports = [
   ]),
   generateReports('March', 2024, [
     `${HOST_URL}2024%2F03%2FEdustipend%20Beneficiaries%20List%20-%20March%202024.pdf?alt=media`,
-    `${HOST_URL}2024%2F03%2FEdustipend%20Applications%20Report%20-%20March%202024.pdf?alt=media`
+    `${HOST_URL}2024%2F03%2FEdustipend%20Applications%20Report%20-%20March%202024.pdf?alt=media`,
+    `${HOST_URL}2024%2F03%2FEdustipend%20Beneficiaries%20Report%20-%20March%202024.pdf?alt=media`
+  ]),
+  generateReports('May', 2024, [
+    `${HOST_URL}2024%2F05%2FEdustipend%20Beneficiaries%20List%20-%20May%202024.pdf?alt=media`,
+    `${HOST_URL}2024%2F05%2FEdustipend%20Applications%20Report%20-%20May%202024.pdf?alt=media`
   ])
 ].reverse();
 


### PR DESCRIPTION
1. Updated the reports page: Added the March beneficiary report link, and May report links.
2. Exposed the Support a learner link on the homepage's Navbar.

![image](https://github.com/edustipend/dotorg/assets/99425435/d44e2e9e-f16d-4c0f-b98a-87b07873a1f5)
