### PR TITLE
fix: rendering top 50 referrers on the leaderboard

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
-REACT_APP_API_BASE_URL=https://edustipend-api-dad9440ec9e5.herokuapp.com
+REACT_APP_API_BASE_URL=https://edustipend-prod-api-a50ab4139ff7.herokuapp.com
 REACT_APP_API_VERSION=v1
 REACT_APP_GTM=GTM-5X26LWRX

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
-REACT_APP_API_BASE_URL=https://edustipend-prod-api-a50ab4139ff7.herokuapp.com
+REACT_APP_API_BASE_URL=https://edustipend-api-dad9440ec9e5.herokuapp.com
 REACT_APP_API_VERSION=v1
 REACT_APP_GTM=GTM-5X26LWRX

--- a/src/pages/refer-page/ReferPage.test.js
+++ b/src/pages/refer-page/ReferPage.test.js
@@ -80,7 +80,7 @@ describe('ReferPage', () => {
     // Simulate clicking the "Copy" button
     fireEvent.click(screen.getByText(referPageTexts.referralLinkCopy));
 
-    await new Promise((r) => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, 1000));
     expect(screen.getByText('Copied!')).toBeInTheDocument();
   });
 });

--- a/src/pages/refer-page/internals/LeaderboardTable.jsx
+++ b/src/pages/refer-page/internals/LeaderboardTable.jsx
@@ -16,7 +16,7 @@ export const LeaderboardTable = ({ referralType }) => {
   const endIndex = startIndex + itemToRender;
   const referrals = referralType === REFERRAL_COUNT ? referralByCount : referralByAmount;
   const leaderboard = referrals?.slice(startIndex, endIndex);
-  const total = leaderboard?.length >= 20 ? 20 : leaderboard?.length;
+  const total = referrals?.length;
   const totalPages = Math.ceil(total / itemToRender);
   const isMobile = window.innerWidth <= 768;
   const tableHeadings = isMobile ? tableHeads[referralType].mobile : tableHeads[referralType].desktop;
@@ -46,7 +46,7 @@ export const LeaderboardTable = ({ referralType }) => {
         </thead>
         <tbody>
           {leaderboard?.map((item, i) => (
-            <TableRow item={{ ...item, index: i + 1 }} key={i} />
+            <TableRow item={{ ...item, index: i + 1 + (currentPage - 1) * 10 }} key={i} />
           ))}
         </tbody>
         <tfoot>

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -13,8 +13,8 @@ export const ONE_CLICK_APPLY = 'stipend/apply/one-click';
 export const LOGOUT = 'logout';
 export const APPLICATION_WINDOW_STATUS = 'application-window';
 export const DONATION = 'donation';
-export const REFERRAL_BY_AMOUNT = 'referral/top-referrers-by-amount';
-export const REFERRAL_BY_COUNT = 'referral/top-referrers-by-count';
+export const REFERRAL_BY_AMOUNT = 'referral/top-referrers-by-amount?top=50';
+export const REFERRAL_BY_COUNT = 'referral/top-referrers-by-count?top=50';
 export const REFERRAL_LINK = 'referral/link';
 
 export const authorizedPost = async function (route = '', data = {}) {


### PR DESCRIPTION
## Checklist
- [x] Added the `top=50` query to the referral endpoints to get the top 50 referrers.
- [x] Rendered all the referrers to the table with correct number ranking and pagination.
- [x] Fixed failing test case.

## Screenshots

![Screenshot 2024-08-29 183930](https://github.com/user-attachments/assets/96565ae0-f56b-41a6-8b4e-4b0f2bb7f4e7)
![Screenshot 2024-08-29 183916](https://github.com/user-attachments/assets/eb9b5c81-87ca-4933-96e6-cf1e173edb8b)
![Screenshot 2024-08-29 183900](https://github.com/user-attachments/assets/80240154-af2a-4602-a72a-1549c8ebb622)
![Screenshot 2024-08-29 183844](https://github.com/user-attachments/assets/41fe34e3-59f2-4a0d-82ba-bd66c262c0fb)
![Screenshot 2024-08-29 183829](https://github.com/user-attachments/assets/ab684453-71f8-42d5-8804-391811b80c5a)
![Screenshot 2024-08-29 183816](https://github.com/user-attachments/assets/48264193-1879-44ed-88dc-7fcbe9f24bfe)
