### PR TITLE
modifications: transparency dashboard

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -26,7 +26,7 @@ import ReferPage from './pages/refer-page/ReferPage';
 import SupportALearnerCampaign from './pages/campaigns/support-a-learner-campaign';
 import { Terms, Privacy } from './pages/legal';
 import { routesConstant } from './routesConstant';
-import { Communities } from './pages/communities';
+import { Communities } from './pages/Communities';
 
 const {
   AMBASSADOR_PROGRAM,

--- a/src/sections/TransparencyDashboard/TransparencyDashboard.jsx
+++ b/src/sections/TransparencyDashboard/TransparencyDashboard.jsx
@@ -1,4 +1,4 @@
-import { TestId, paths, resData } from './constants';
+import { TestId, isCampaignActive, paths, resData } from './constants';
 import Container from '../../components/Container';
 import { useCallback, useEffect, useState } from 'react';
 import { DashboardTimelines, DonationsFilter, Goals } from './internals';
@@ -66,7 +66,7 @@ export const TransparencyDashboard = () => {
         <BreadCrumbs paths={paths} />
         <div className={styles.topSection}>
           <DonationsFilter amountRaised={data?.amountRaised} handleOptionChange={handleOptionChange} />
-          <Goals data={data} />
+          <Goals data={data} isCampaignActive={isCampaignActive} />
         </div>
         <DashboardTimelines donations={data?.donations} total={data?.total} next={data?.next} setNextCall={setNextCall} />
       </Container>

--- a/src/sections/TransparencyDashboard/constants.js
+++ b/src/sections/TransparencyDashboard/constants.js
@@ -1,5 +1,7 @@
 import { Goal_Icon, User_Icon } from '../../assets';
 
+export const isCampaignActive = false; // This should be dynamically set based on the campaign status
+
 export const targets = [
   {
     icon: Goal_Icon,

--- a/src/sections/TransparencyDashboard/internals/Goals.jsx
+++ b/src/sections/TransparencyDashboard/internals/Goals.jsx
@@ -7,33 +7,36 @@ import PropTypes from 'prop-types';
 import styles from '../TransparencyDashboard.module.css';
 import Button from '../../../components/Button';
 
-export const Goals = ({ data }) => {
+export const Goals = ({ data, isCampaignActive }) => {
   return (
     <div className={styles.goals} data={data} data-testid={TestId.GOALS_ID}>
       <div className={styles.top}>
-        {targets.map((t) => (
-          <Target
-            key={t.value}
-            value={t.category === 'goal' ? formatMoney(data[t.category]) : data[t.category]}
-            category={t.category}
-            icon={t.icon}
-          />
-        ))}
+        {targets.map((t) => {
+          if (t.category === 'goal' && !isCampaignActive) return null;
+
+          const value = t.category === 'goal' ? formatMoney(data?.[t.category]) : data?.[t.category];
+
+          return <Target key={t.category} value={value} category={t.category} icon={t.icon} />;
+        })}
       </div>
       <div className={styles.bottom}>
         <div className={styles.progress}>
           <div className={styles.progressTop}>
             <h1>
-              {formatMoney(data?.raised)} / <span>{formatMoney(data?.goal)}</span>
+              {formatMoney(data?.raised)}
+              {isCampaignActive && <span> / {formatMoney(data?.goal)}</span>}
             </h1>
             <p>Raised</p>
           </div>
-          <div className={styles.progressContainer}>
-            <div className={styles.progressBar}>
-              <div className={styles.progressFill} style={{ width: `${data?.completed}%` }}></div>
+
+          {isCampaignActive && (
+            <div className={styles.progressContainer}>
+              <div className={styles.progressBar}>
+                <div className={styles.progressFill} style={{ width: `${data?.completed}%` }}></div>
+              </div>
+              <p className={styles.completion}>{data?.completed}% complete</p>
             </div>
-            <p className={styles.completion}>{data?.completed}% complete</p>
-          </div>
+          )}
         </div>
 
         <Link to={btn.path} className={styles.link}>
@@ -45,5 +48,6 @@ export const Goals = ({ data }) => {
 };
 
 Goals.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.object,
+  isCampaignActive: PropTypes.bool
 };


### PR DESCRIPTION
- Conditionally rendered the goal target and progress bar based on `isCampaignActive` prop.
- Ensured only contributors are shown when no active campaign is running.
- Improved UI flexibility for switching between active and inactive campaign states.

<img width="1362" height="601" alt="image" src="https://github.com/user-attachments/assets/57dff85d-9499-4a0a-a045-373de02396c1" />
